### PR TITLE
A number of customizations for convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,43 @@
 # bash-otp
+
+## Changes made in this fork
+* Allow supplying password to otp scripts with stdin. Example use case: `fn_get_pass | ./otp.sh tokenfiles/file.enc`
+* Specify token file by path, rather than by filename (allows for tab completion)
+* Use `-pbkdf2` with all `openssl enc` operations (see `man openssl enc`)
+* Supply passwords to `openssl` with stdin instead of temp files
+* Remove functionality for reading tokens from plaintext files, assume encrypted
+* Supply a script `import-gauth-json.sh` that imports from Google Authenticator with the help of [krissrex/google-authenticator-exporter](https://github.com/krissrex/google-authenticator-exporter)
+
+### Suggested helper configuration
+I opted to store the password used for encrypting my token files in my password manager, Bitwarden. Thus, my config uses the Bitwarden CLI. You can achieve something similar with the LastPass CLI, KeePass, etc.
+```bash
+export BASH_OTP_TOKENFILES_DIR="/home/zach/tokenfiles"
+
+function bwunlock() { export BW_SESSION=$(bw unlock --raw) }
+
+function otpgetpass() {
+  if [ $(bw status | jq -r '.status') != 'unlocked' ]; then
+    echo "Bitwarden is locked" >&2
+    return 1
+  fi
+  bw get password "<id-of-vault-item>"
+}
+
+function otp() {
+  local pass
+  pass="$(otpgetpass)" || return $?
+  echo "$pass" | ~/git/bash-otp/otp.sh "$@"
+}
+
+function otpadd() {
+  local pass
+  pass="$(otpgetpass)" || return $?
+  echo "$pass" | ~/git/bash-otp/otp-lockfile.sh "$@"
+}
+```
+
+## Original readme
+
 One-Time Password generator for CLI using bash, oathtool.
 
 Automatically copys the token into your computer's copy buffer (MacOS only atm)

--- a/import-gauth-json.sh
+++ b/import-gauth-json.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# For use with https://github.com/krissrex/google-authenticator-exporter
+
+jsonfile=$1
+
+read -s -r -p "Password to lock file: " password1
+read -s -r -p "Enter that password again: " password2
+
+if [[ "${password1}" != "${password2}" && "${password2}" != "" ]]; then
+    echo "The passwords do not match; try that again"
+    exit 1
+fi
+
+jq -c '.[]' $jsonfile | while read item; do
+  name="$(echo $item | jq -r '.name')"
+  totpSecret="$(echo $item | jq -r '.totpSecret')"
+
+  input_file="./tokenfiles/${name}"
+  echo "$totpSecret" >> "$input_file"
+
+  echo "${password1}" | openssl enc -aes-256-cbc -pbkdf2 -salt -in "$input_file" -out "${input_file}.enc" -pass stdin && rm "$input_file"
+done

--- a/otp-lockfile.sh
+++ b/otp-lockfile.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bash
-set -e
 
 # Examples, all use password-based encryption:
 # Encrypt file to file
-#openssl enc -aes-256-cbc -salt -in file.txt -out file.txt.enc
+#openssl enc -aes-256-cbc -pbkdf2 -salt -in file.txt -out file.txt.enc
 # Decrypt file to stdout
-#openssl enc -aes-256-cbc -d -salt -in file.txt.enc
+#openssl enc -aes-256-cbc -pbkdf2 -d -salt -in file.txt.enc
 # Decrypt file to file
-#openssl enc -aes-256-cbc -d -salt -in file.txt.enc -out file.txt
+#openssl enc -aes-256-cbc -pbkdf2 -d -salt -in file.txt.enc -out file.txt
 
 INPUT_FILE="$1"
-PW_FILE=$( mktemp pwfile.XXXXXXXX )
 
 echo "WARNING: THIS WILL DELETE THE ORIGINAL FILE"
 
@@ -22,15 +20,12 @@ fi
 read -s -r -p "Password to lock file: " PASSWORD1
 read -s -r -p "Enter that password again: " PASSWORD2
 
-if [[ "${PASSWORD1}" == "${PASSWORD2}" ]]; then
-
-    echo "${PASSWORD1}" > "${PW_FILE}"
-    openssl enc -aes-256-cbc -salt -in "${INPUT_FILE}" -out "${INPUT_FILE}.enc" -pass file:"${PW_FILE}" && rm "${INPUT_FILE}" && rm "${PW_FILE}"
+if [[ "${PASSWORD1}" == "${PASSWORD2}" || "${PASSWORD2}" == "" ]]; then
+    echo "${PASSWORD1}" | openssl enc -aes-256-cbc -pbkdf2 -salt -in "${INPUT_FILE}" -out "${INPUT_FILE}.enc" -pass stdin && rm "${INPUT_FILE}"
     echo "Decrypt this file using the following command:"
-    echo "openssl enc -aes-256-cbc -d -salt -in ${INPUT_FILE}.enc -out ${INPUT_FILE}"
+    echo "openssl enc -aes-256-cbc -pbkdf2 -d -salt -in ${INPUT_FILE}.enc -out ${INPUT_FILE}"
 else
     echo "The passwords do not match; try that again"
-    rm "${PW_FILE}"
     exit 1
 fi
 

--- a/otp-unlockfile.sh
+++ b/otp-unlockfile.sh
@@ -13,7 +13,6 @@ set -e
 
 INPUT_FILE="$1"
 OUTPUT_FILE=$( echo $INPUT_FILE | sed 's/.enc//' )
-PW_FILE=$( mktemp pwfile.XXXXXXXX )
 
 if [ ! -f "${INPUT_FILE}" ]; then
     echo "The file [${INPUT_FILE}] does not exist"
@@ -22,6 +21,4 @@ fi
 
 read -s -r -p "Password to unlock file: " PASSWORD1
 
-echo "${PASSWORD1}" > "${PW_FILE}"
-openssl enc -aes-256-cbc -d -salt -in "${INPUT_FILE}" -out "${OUTPUT_FILE}" -pass file:"${PW_FILE}"
-rm "${PW_FILE}"
+echo "${PASSWORD1}" | openssl enc -aes-256-cbc -pbkdf2 -d -salt -in "${INPUT_FILE}" -out "${OUTPUT_FILE}" -pass stdin


### PR DESCRIPTION
* Allow supplying password to otp scripts with stdin. Example use case: fn_get_pass | ./otp.sh tokenfiles/file.enc
* Specify token file by path, rather than by filename (allows for tab completion)
* Use -pbkdf2 with all openssl enc operations (see man openssl enc)
* Supply passwords to openssl with stdin instead of temp files
* Remove functionality for reading tokens from plaintext files, assume encrypted
* Supply a script import-gauth-json.sh that imports from Google Authenticator with the help of krissrex/google-authenticator-exporter